### PR TITLE
Add `gulp server` capability

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,4 +44,5 @@ module.exports.browserifyHelper = function(inputFile, options) {
   return rebundle();
 };
 
+module.exports.runServer = require('./lib/server');
 module.exports.tiberius = require('./tiberius');

--- a/lib/apiroute.js
+++ b/lib/apiroute.js
@@ -1,0 +1,70 @@
+'use strict'
+
+var ROUTES = {
+  'local': 'http://api.lcl.mbq.io:8000',
+  'development': 'https://api.dev.mbq.io',
+  'staging': 'https://api.stg.mbq.io',
+  'production': 'https://api.managedbyq.com'
+};
+
+/*
+ *  apiRoute
+ *  Uses api environment variable to set a base url to proxy API calls through.
+ *  @param {Express} app Express app to call to.
+ *  @param {Object} opts Options object. Currently unused.
+ *  @param {Object} locals Contains captured environment variables
+ *
+ *  @param {String} locals.api Flag to determine base url to route to.
+ *                  local || development (default) || staging || production
+ *  @param {String} locals.api_endpoint Base URL to directly use. Will override
+ *                  url set by locals.api
+ */
+function apiRoute (app, opts, locals) {
+
+  var baseAPIURL = ROUTES[locals.api];
+
+  if (typeof opts.request === 'undefined') {
+    throw new Error('Request is required to run ApiRoute');
+  }
+
+  if (typeof baseAPIURL === 'undefined') {
+    baseAPIURL = ROUTES.local;
+  }
+
+  if (typeof locals.api_endpoint !== 'undefined') {
+    baseAPIURL = locals.api_endpoint;
+  }
+
+  var request = opts.request;
+  console.log('API URL:', baseAPIURL);
+
+  // capture all requests to relative /api
+  app.use('/api', function(req, res) {
+
+    var url = baseAPIURL + '/api' + req.url;
+    console.log('proxying ' + url);
+
+    var r = null;
+    switch (req.method) {
+      case 'POST':
+        r = request.post({uri: url, json: req.body});
+        break;
+      case 'PUT':
+        r = request.put({uri: url, json: req.body});
+        break;
+      case 'PATCH':
+        r = request.patch({uri: url, json: req.body});
+        break;
+      case 'OPTIONS':
+        r = request({uri: url, json: req.body});
+        break;
+      default:
+        r = request(url);
+        break;
+    }
+
+    req.pipe(r).pipe(res);
+  });
+};
+
+module.exports = apiRoute;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var http = require('http');
+
+var _ = require('lodash');
+var async = require('async');
+var express = require('express');
+var request = require('request');
+
+var apiRoute = require('./apiroute');
+
+function staticServer (appName, port) {
+  var app = express();
+  var server = http.createServer(app);
+  app.use('/'+appName, express.static('./build'));
+  server.on('listening', function () {
+    console.log('%s statics listening on %s', appName, port);
+  });
+  server.on('error', function (err) {
+    console.error('error');
+  });
+  server.listen = _.partial(server.listen.bind(server), port);
+  return server;
+}
+
+function apiRouteServer () {
+  var app = express();
+  var server = http.createServer(app);
+  var routeOpts = {request: request};
+  var locals = {
+    api: process.env.API || 'local',
+    api_endpoint: process.env.API_ENDPOINT
+  };
+  apiRoute(app, routeOpts, locals);
+  server.on('listening', function () {
+    console.log('apiRoute listening on 4000 with settings: ', locals);
+  });
+  server.on('error', function (err) {
+    if (err.code === 'EADDRINUSE') {
+      console.log('Another apiRoute is already running');
+    } else {
+      throw err;
+    }
+  });
+  server.listen = _.partial(server.listen.bind(server), 4000);
+  return server;
+}
+
+module.exports = function runServer (appName, port, callback) {
+  var staticApp = staticServer(appName, port);
+  var apiRouteApp = apiRouteServer();
+  async.parallel([
+    staticApp.listen.bind(staticApp),
+    apiRouteApp.listen.bind(apiRouteApp)
+  ], callback);
+};

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "watchify": "~3.2.1"
   },
   "devDependencies": {
+    "express": "^4.13.3",
     "gulp-jshint": "^2.0.0",
     "jshint": "^2.8.0",
-    "jshint-stylish": "^2.1.0"
+    "jshint-stylish": "^2.1.0",
+    "request": "^2.67.0"
   },
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
There are a couple purposes to this PR:
1. Get rid of custom `server.js` files in frontend repos
2. Ability to run OMD and SuperPanel at the same time

Regarding number 2, the approach works like this:
- `frontend` will serve statics on port 4001
- `omd` will serve statics on port 4002
- _Both_ repos will _try_ to run `apiRoute` on port 4000. If that port is already in use, it assumes the other repo is already running
- Of course, `os-core` will be updated to serve statics from the correct locations

I'll be following with PRs in `os-core`, `frontend`, and `omd`. I just want to cut a new version of `gulp-utils` first.
