### PR TITLE
Upgrade runServer for use in all frontend apps

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -4,17 +4,21 @@ var http = require('http');
 
 var _ = require('lodash');
 var async = require('async');
+var cors = require('cors');
 var express = require('express');
 var request = require('request');
 
 var apiRoute = require('./apiroute');
 
-function staticServer (appName, port) {
+function staticServer (path, port, customBehavior) {
   var app = express();
   var server = http.createServer(app);
-  app.use('/'+appName, express.static('./build'));
+  app.use(path, express.static('./build'));
+  if (customBehavior) {
+    customBehavior(app);
+  }
   server.on('listening', function () {
-    console.log('%s statics listening on %s', appName, port);
+    console.log('statics listening on port: %s, path: %s', port, path);
   });
   server.on('error', function (err) {
     console.error('error');
@@ -25,6 +29,8 @@ function staticServer (appName, port) {
 
 function apiRouteServer () {
   var app = express();
+  // allow CORS from any domain
+  app.use(cors({origin: true, preflightContinue: true}));
   var server = http.createServer(app);
   var routeOpts = {request: request};
   var locals = {
@@ -46,8 +52,12 @@ function apiRouteServer () {
   return server;
 }
 
-module.exports = function runServer (appName, port, callback) {
-  var staticApp = staticServer(appName, port);
+module.exports = function runServer (path, port, customBehavior, callback) {
+  if (!callback) {
+    callback = customBehavior;
+    customBehavior = null;
+  }
+  var staticApp = staticServer(path, port, customBehavior);
   var apiRouteApp = apiRouteServer();
   async.parallel([
     staticApp.listen.bind(staticApp),

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "watchify": "~3.2.1"
   },
   "devDependencies": {
+    "cors": "^2.7.1",
     "express": "^4.13.3",
     "gulp-jshint": "^2.0.0",
     "jshint": "^2.8.0",


### PR DESCRIPTION
The next generation of `runServer`. Apps that have customized behavior will pass an additional argument. For example, `marketing` will implement its 404 page logic like this:

``` javascript
gulp.task('server', function (cb) {
  var port = process.env.PORT || 2000;
  var customBehavior = function (app) {
    app.use(function(req, res){
      res.sendFile(__dirname + '/build/404/index.html');
    });
  };
  gulpUtils.runServer('/', port, customBehavior, cb);
});
```

After I cut a release for this I'll send PRs for `omd`, `frontend`, `q-harrison`, and `marketing`. I'm leaving `operator` out of the mix for now because its requirements are really special, and it already has its own fork of `apiRoute`. I'll also be able to remove `qlib.apiRoute` after this--I don't believe anything will be using it anymore.
