### PR TITLE
Make slack notifications green instead of orange

### DIFF
--- a/lib/tiberius.js
+++ b/lib/tiberius.js
@@ -27,9 +27,7 @@ function sendSlackMessage(options, cb) {
       'color': 'good',
       'mrkdwn_in': ['text']
     }]),
-    icon_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Tiberius%2C_Romisch-' +
-              'Germanisches_Museum%2C_Cologne_%288115606671%29.jpg/440px-Tiberius' +
-              '%2C_Romisch-Germanisches_Museum%2C_Cologne_%288115606671%29.jpg',
+    icon_url: 'http://i.imgur.com/pAMdaSt.jpg',
     username: 'Tiberius'
   }, cb);
 }


### PR DESCRIPTION
Perhaps I will start a flame war over this, but...

I think if something normal happened (like a deploy) and it succeeded, we should see a green message in Slack instead of an orange one. That is what we're currently doing for os-core: green means success, red means failure.

I'm not seeing `sendSlackMessage` used for errors/warnings, so I hard-coded it to green. It could easily be extended in the future if we wanted to pass in the color.

I also updated the Tiberius icon URL to a version I uploaded to imgur.
