### PR TITLE
don't swallow errors during s3 asset upload

### DIFF
--- a/lib/s3upload.js
+++ b/lib/s3upload.js
@@ -37,7 +37,9 @@ function upload(config, cb) {
         s3Params: s3Params,
         getS3Params: getS3Params
       });
-      uploader.on('error', cb);
+      uploader.on('error', function() {
+        cb('Error while uploading to s3');
+      });
       uploader.on('fileUploadEnd', function (localFilePath, s3Key) {
         console.log('Uploaded ' + config.bucket + '/' + s3Key);
       });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-utils",
   "private": "true",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Shared Gulp resources",
   "author": "Q",
   "dependencies": {


### PR DESCRIPTION
We silently failed to upload one asset during the frontend deploy that just happened. Our upload code was swallowing errors.
