### PR TITLE
kill essentially useless gulp-utils code

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -25,7 +25,7 @@ var tiberius = require('./tiberius');
  * @returns {{}}
  */
 module.exports.create = function (config) {
-  var prevVersion, versionToDeploy;
+  var versionToDeploy;
 
   var pushAssets = function (cb) {
     if (config.test) {
@@ -105,23 +105,6 @@ module.exports.create = function (config) {
       });
   };
 
-  var getPrevProdVersion = function (cb) {
-    if (config.test) {
-      console.log('Simulating fetch of prod version');
-      prevVersion = '2.1.5';
-      cb(null);
-      return;
-    }
-    tiberius.mostRecentProductionRelease(
-      config.credentials.prodApplicationToken,
-      config.applicationName,
-      function (err, version) {
-        console.log('Current version on production is ' + version);
-        prevVersion = version;
-        cb(err);
-      });
-  };
-
   var getStaticVersion = function (env, bucket, cb) {
     if (config.test) {
       console.log('Simulating fetch of ' + env + ' version');
@@ -141,13 +124,6 @@ module.exports.create = function (config) {
       var version = JSON.parse(json).version;
       console.log('Current version on ' + env + ' is ' + version);
       cb(null, version);
-    });
-  };
-
-  var getPrevProdStaticVersion = function (cb) {
-    getStaticVersion('prod', config.staticSite.prodS3Bucket, function (err, version) {
-      prevVersion = version;
-      cb(err);
     });
   };
 
@@ -192,14 +168,11 @@ module.exports.create = function (config) {
 
   return {
     devDeploy: function (cb) {
-      async.series([getPrevProdVersion, pushAssets, releaseToDev], cb);
+      async.series([pushAssets, releaseToDev], cb);
     },
     prodDeploy: function (version, cb) {
       versionToDeploy = version;
-      var steps = [
-        getPrevProdVersion,
-        productionDeploy,
-        stagingDeploy
+      var steps = [productionDeploy, stagingDeploy
       ];
 
       if (!versionToDeploy) {
@@ -210,18 +183,12 @@ module.exports.create = function (config) {
     },
     devStaticDeploy: function (cb) {
       async.series(
-        [getPrevProdStaticVersion,
-          writeStaticVersion,
-          pushDevStaticAssets],
+        [writeStaticVersion, pushDevStaticAssets],
         cb);
     },
     prodStaticDeploy: function (version, cb) {
       versionToDeploy = version;
-      var steps = [
-        getPrevProdStaticVersion,
-        writeStaticVersion,
-        pushStgAndProdStaticAssets
-      ];
+      var steps = [writeStaticVersion, pushStgAndProdStaticAssets];
 
       if (!versionToDeploy) {
         steps.unshift(getDevStaticVersion);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-utils",
   "private": "true",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Shared Gulp resources",
   "author": "Q",
   "dependencies": {


### PR DESCRIPTION
a step along slimming down gulp-utils and going back to gulp-awspublish
(The code I'm deleting is run but it now does nothing as diffs don't run in gulp-utils.)
