### PR TITLE
work around S3 or client bug - don't consider an upload successful unless both the Bucket and the Key are confirmed

### DIFF
--- a/lib/s3upload.js
+++ b/lib/s3upload.js
@@ -56,14 +56,19 @@ function toUploadTask(config) {
         objectName: uploadParameters.objectName,
         file: uploadParameters.filename,
         headers: uploadParameters.headers
-      }, cb);
+      });
 
       upload.on('error', function (err) {
         console.log('Error uploading ' + err);
+        cb(err);
       });
 
       upload.on('completed', function (body) {
-        console.log('Uploaded ' + body.Bucket + '/' + body.Key);
+        if (body.Bucket && body.Key) {
+          console.log('Uploaded ' + body.Bucket + '/' + body.Key);
+          return cb();
+        }
+        return cb('Upload failed (S3 response did not include both the Bucket and the Key).');
       });
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-utils",
   "private": "true",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Shared Gulp resources",
   "author": "Q",
   "dependencies": {


### PR DESCRIPTION
Because we retry uploads 3 times, we should succeed eventually. Logs show that we occasionally get undefined values for the Bucket and the Key. Can't see any reason besides an S3 bug for that.
