### PR TITLE
Add optional parameter for API Route Server port

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -41,7 +41,7 @@ function apiRouteServer (apiRoutePort) {
   };
   apiRoute(app, routeOpts, locals);
   server.on('listening', function () {
-    console.log('apiRoute listening on '+ apiRoutePort + ' with settings: ', locals);
+    console.log('apiRoute listening on ' + apiRoutePort + ' with settings: ', locals);
   });
   server.on('error', function (err) {
     if (err.code === 'EADDRINUSE') {

--- a/lib/server.js
+++ b/lib/server.js
@@ -29,7 +29,7 @@ function staticServer (path, port, customBehavior) {
   return server;
 }
 
-function apiRouteServer () {
+function apiRouteServer (apiRoutePort) {
   var app = express();
   // allow CORS from any domain
   app.use(cors({origin: true, preflightContinue: true}));
@@ -41,7 +41,7 @@ function apiRouteServer () {
   };
   apiRoute(app, routeOpts, locals);
   server.on('listening', function () {
-    console.log('apiRoute listening on 4000 with settings: ', locals);
+    console.log('apiRoute listening on '+ apiRoutePort + ' with settings: ', locals);
   });
   server.on('error', function (err) {
     if (err.code === 'EADDRINUSE') {
@@ -50,17 +50,18 @@ function apiRouteServer () {
       throw err;
     }
   });
-  server.listen = _.partial(server.listen.bind(server), 4000);
+  server.listen = _.partial(server.listen.bind(server), apiRoutePort);
   return server;
 }
 
-module.exports = function runServer (path, port, customBehavior, callback) {
+module.exports = function runServer (path, port, customBehavior, callback, apiRoutePort) {
+  apiRoutePort = apiRoutePort || 4000;
   if (!callback) {
     callback = customBehavior;
     customBehavior = null;
   }
   var staticApp = staticServer(path, port, customBehavior);
-  var apiRouteApp = apiRouteServer();
+  var apiRouteApp = apiRouteServer(apiRoutePort);
   async.parallel([
     staticApp.listen.bind(staticApp),
     apiRouteApp.listen.bind(apiRouteApp)


### PR DESCRIPTION
Gulp was hardcoded to use port 4000 for the API Route Server which conflicts with OMD. Thus, if any gulp project (usually Harrison) is active, OMD cannot run locally. 

Now, any service that uses `gulp-utils` can pass in a specific port for the API Route Server to use.